### PR TITLE
feat(utils): add getPascalCaseText and getCamelCaseText

### DIFF
--- a/src/Common.ts
+++ b/src/Common.ts
@@ -82,15 +82,36 @@ export const convertToEuropeFormat = (value: number): string =>
     });
 
 /**
- * Converts a given text to camelCase format.
+ * Converts a string to camelCase.
+ * Removes all non-alphabetic characters and converts the result to camelCase,
+ * where the first word is in lowercase and subsequent words are capitalized.
  *
- * @param {string} text - The input text to be converted.
- * @returns {string} The input text converted to camelCase format.
+ * @param {string} text - The input string to convert to camelCase.
+ * @returns {string} The input string converted to camelCase.
  */
 export const getCamelCaseText = (text: string): string => {
-    const words = text.split(' ');
+    return text
+        .replace(/[^a-zA-Z]+/g, ' ')
+        .trim()
+        .toLowerCase()
+        .split(/\s+/)
+        .map((word, index) => index === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1))
+        .join('');
+};
 
-    return words[0].charAt(0).toUpperCase() + words[0].slice(1).toLowerCase();
+/**
+ * Converts a given text to PascalCase format.
+ * Removes all non-alphabetic characters before converting to PascalCase.
+ *
+ * @param {string} text - The input text to be converted.
+ * @returns {string} The input text converted to PascalCase format.
+ */
+export const getPascalCaseText = (text: string): string => {
+    const words = text.replace(/[^a-zA-Z ]+/g, ' ').split(' ').filter(Boolean);
+
+    return words
+        .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+        .join('');
 };
 
 /**

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -8,6 +8,7 @@ import {
     splitTextAndGetPart,
     normalizeWhitespacesAndRemoveSoftHyphen,
     convertToEuropeFormat,
+    getPascalCaseText,
     getCamelCaseText,
     getExecutionTime,
     extractTextOnly,
@@ -69,8 +70,29 @@ test('convertToEuropeFormat should format numbers in European format', () => {
 });
 
 test('getCamelCaseText should convert text to camelCase', () => {
-    expect(getCamelCaseText('hello world')).toBe('Hello');
-    expect(getCamelCaseText('JAVASCRIPT testing')).toBe('Javascript');
+    expect(getCamelCaseText('hello')).toBe('hello');
+    expect(getCamelCaseText('hello world')).toBe('helloWorld');
+    expect(getCamelCaseText('JAVASCRIPT testing')).toBe('javascriptTesting');
+    expect(getCamelCaseText('e-Scooter')).toBe('eScooter');
+    expect(getCamelCaseText('Giant+nutella')).toBe('giantNutella');
+    expect(getCamelCaseText('oppa gangnam-Style')).toBe('oppaGangnamStyle');
+    expect(getCamelCaseText('   spaced    words   ')).toBe('spacedWords');
+    expect(getCamelCaseText('123 Number 4 Test!')).toBe('numberTest');
+    expect(getCamelCaseText('')).toBe('');
+    expect(getCamelCaseText('!@#$%^&*()')).toBe('');
+});
+
+test('getPascalCaseText should convert text to PascalCase', () => {
+    expect(getPascalCaseText('hello')).toBe('Hello');
+    expect(getPascalCaseText('hello world')).toBe('HelloWorld');
+    expect(getPascalCaseText('JAVASCRIPT testing')).toBe('JavascriptTesting');
+    expect(getPascalCaseText('e-Scooter')).toBe('EScooter');
+    expect(getPascalCaseText('Giant+nutella')).toBe('GiantNutella');
+    expect(getPascalCaseText('oppa gangnam-Style')).toBe('OppaGangnamStyle');
+    expect(getPascalCaseText('   spaced    words   ')).toBe('SpacedWords');
+    expect(getPascalCaseText('123 Number 4 Test!')).toBe('NumberTest');
+    expect(getPascalCaseText('')).toBe('');
+    expect(getPascalCaseText('!@#$%^&*()')).toBe('');
 });
 
 test('getExecutionTime should calculate the execution time in seconds', () => {


### PR DESCRIPTION
This PR introduces two new utility functions, getPascalCaseText and getCamelCaseText, which provide text conversion to PascalCase and camelCase formats, respectively.

**Changes:**
getPascalCase:
- Converts a given string to PascalCase format.
- In PascalCase, each word starts with a capital letter, and there are no spaces or punctuation between words.
- Example: 
-- "hello world" → "HelloWorld"
-- "convert to pascal case" → "ConvertToPascalCase"

getCamelCaseText:
- Converts a given string to camelCase format.
- In camelCase, the first word is lowercase, and subsequent words are capitalized without spaces or punctuation.
- Example:
-- "hello world" → "helloWorld"
-- "convert to camel case" → "convertToCamelCase"