### PR TITLE
refactor: update generateRandomArray to return 0 if array has length 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [1.9.0](https://github.com/basal-john/essential-common-utils/compare/v1.8.4...v1.9.0) (2025-03-27)
 
-
 ### Features
 
-* add textHelper utility functions for HTML entity decoding and text normalization ([22c725d](https://github.com/basal-john/essential-common-utils/commit/22c725dfec5cb5994ea86d3689d17958b697a529))
+- add textHelper utility functions for HTML entity decoding and text normalization ([22c725d](https://github.com/basal-john/essential-common-utils/commit/22c725dfec5cb5994ea86d3689d17958b697a529))
 
 ### [1.8.4](https://github.com/basal-john/essential-common-utils/compare/v1.8.3...v1.8.4) (2025-03-18)
 

--- a/src/Common.ts
+++ b/src/Common.ts
@@ -6,8 +6,16 @@ import extractUrls from 'extract-urls';
  * @param {number} arrayLength - The length of the array. Default is 5.
  * @returns {number} A random index for the array.
  */
-export const generateRandomArrayIndex = (arrayLength: number = 5): number =>
-    Math.floor(Math.random() * arrayLength) || 1;
+export const generateRandomArrayIndex = (arrayLength: number = 5): number => Math.floor(Math.random() * arrayLength);
+
+/**
+ * Generates a random number between 1 and the given length.
+ * If length is 0 or negative, it defaults to 1.
+ *
+ * @param {number} maxValue - The maximum value for the random number.
+ * @returns {number} A random number between 1 and maxValue (or 1 if length is invalid).
+ */
+export const generateRandomNumber = (maxValue: number = 5): number => Math.floor(Math.random() * maxValue) || 1;
 
 /**
  * Trims a string and removes all spaces.

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -17,12 +17,27 @@ import {
     getMultipleUniqueIndexes,
     getRandomString,
     parsePricesWithLocaleFormatting,
+    generateRandomNumber,
     textHelper,
 } from '../src/Common';
 
 test('generateRandomArrayIndex should return a number within range', () => {
     const arrayLength = 10;
     const index = generateRandomArrayIndex(arrayLength);
+
+    expect(index).toBeLessThan(arrayLength);
+});
+
+test('generateRandomArrayIndex should return  0 if the array has length 1', () => {
+    const arrayLength = 1;
+    const index = generateRandomArrayIndex(arrayLength);
+
+    expect(index).toEqual(0);
+});
+
+test('generateRandomNumber should return a number within range', () => {
+    const arrayLength = 10;
+    const index = generateRandomNumber(arrayLength);
 
     expect(index).toBeGreaterThanOrEqual(0);
     expect(index).toBeLessThan(arrayLength);


### PR DESCRIPTION
Refactor generateRandomArrayIndex to Handle Edge Case for Length 1 and Introduce generateRandomNumber

**Issue**: The previous implementation of generateRandomArrayIndex returned 1 when the array length was 1, which was incorrect since the valid index for an array of length 1 is 0.

**Changes**:

Refactored generateRandomArrayIndex to correctly return 0 for arrays with length 1.

Introduced a new function, generateRandomNumber, which generates a random number between 1 and the provided maxValue.