### PR TITLE
Fix docs, random number range and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Essential common utilities
 
-A collection of essesntial utility functions for various common operations in JavaScript and TypeScript projects. The `essential-common-utils` package provides a set of reusable functions for string manipulation, number formatting, URL extraction, and more.
+A collection of essential utility functions for various common operations in JavaScript and TypeScript projects. The `essential-common-utils` package provides a set of reusable functions for string manipulation, number formatting, URL extraction, and more.
 
 ## Utility Functions
 
@@ -128,7 +128,7 @@ Capitalizes the first word and makes the rest lowercase.
 - **Example**:
     ```typescript
     const result = capitalizeFirstWord('hello world');
-    // Output: "Hello world"
+    // Output: "Hello"
     ```
 
 ---

--- a/src/Common.ts
+++ b/src/Common.ts
@@ -15,7 +15,11 @@ export const generateRandomArrayIndex = (arrayLength: number = 5): number => Mat
  * @param {number} maxValue - The maximum value for the random number.
  * @returns {number} A random number between 1 and maxValue (or 1 if length is invalid).
  */
-export const generateRandomNumber = (maxValue: number = 5): number => Math.floor(Math.random() * maxValue) || 1;
+export const generateRandomNumber = (maxValue: number = 5): number => {
+    if (maxValue <= 0) return 1;
+
+    return Math.floor(Math.random() * maxValue) + 1;
+};
 
 /**
  * Trims a string and removes all spaces.

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -36,11 +36,11 @@ test('generateRandomArrayIndex should return  0 if the array has length 1', () =
 });
 
 test('generateRandomNumber should return a number within range', () => {
-    const arrayLength = 10;
-    const index = generateRandomNumber(arrayLength);
+    const maxValue = 10;
+    const number = generateRandomNumber(maxValue);
 
-    expect(index).toBeGreaterThanOrEqual(0);
-    expect(index).toBeLessThan(arrayLength);
+    expect(number).toBeGreaterThanOrEqual(1);
+    expect(number).toBeLessThanOrEqual(maxValue);
 });
 
 test('trimAndRemoveSpaces should remove spaces from a string', () => {
@@ -125,13 +125,14 @@ test('getPascalCaseText should convert text to PascalCase', () => {
     expect(getPascalCaseText('!@#$%^&*()')).toBe('');
 });
 
-test('getExecutionTime should calculate the execution time in seconds', () => {
+test('getExecutionTime should calculate the execution time in seconds', (done) => {
     const startTime = Date.now();
     // Simulate some delay
     setTimeout(() => {
         const executionTime = getExecutionTime(startTime);
 
         expect(parseFloat(executionTime)).toBeGreaterThan(0);
+        done();
     }, 100);
 });
 


### PR DESCRIPTION
## Summary
- fix README typo and documentation for `capitalizeFirstWord`
- correct range of `generateRandomNumber`
- update the tests for new random number range
- wait for async assertion in `getExecutionTime` test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68406c1e42048333b26faaa6f246bfc8