### PR TITLE
feat: function to format us price

### DIFF
--- a/src/Common.ts
+++ b/src/Common.ts
@@ -102,6 +102,27 @@ export const convertToEuropeFormat = (value: number): string =>
     });
 
 /**
+ * Converts a numeric value to a US-style formatted price string.
+ *
+ * - Uses comma as thousands separator.
+ * - Omits trailing ".00" for whole numbers.
+ * - Retains up to 2 decimal places for fractional values.
+ *
+ * @param {number} value - The numeric value to format.
+ * @returns {string} The formatted price string in US style.
+ *
+ * @example
+ * convertToUSPriceFormat(1699);      // "1,699"
+ * convertToUSPriceFormat(1234567.89);// "1,234,567.89"
+ */
+export const convertToUSPriceFormat=(value:number)=>{
+    return Intl.NumberFormat('en-US', {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 2,
+    }).format(value);
+}
+
+/**
  * Converts a string to camelCase.
  * Removes all non-alphabetic characters and converts the result to camelCase,
  * where the first word is in lowercase and subsequent words are capitalized.

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -18,7 +18,7 @@ import {
     getRandomString,
     parsePricesWithLocaleFormatting,
     generateRandomNumber,
-    textHelper,
+    textHelper, convertToUSPriceFormat,
 } from '../src/Common';
 
 test('generateRandomArrayIndex should return a number within range', () => {
@@ -273,5 +273,16 @@ describe('textHelper', () => {
         testCases.forEach(({actual, expected, result}) => {
             expect(textHelper.compareTexts(actual, expected)).toBe(result);
         });
+    });
+
+    test('should format whole numbers without .00', () => {
+        expect(convertToUSPriceFormat(1699)).toBe('1,699');
+        expect(convertToUSPriceFormat(0)).toBe('0');
+        expect(convertToUSPriceFormat(1000000)).toBe('1,000,000');
+    });
+
+    test('should format numbers with decimals correctly', () => {
+        expect(convertToUSPriceFormat(1234.56)).toBe('1,234.56');
+        expect(convertToUSPriceFormat(0.99)).toBe('0.99');
     });
 });


### PR DESCRIPTION
This PR introduces a new utility function convertToUSPriceFormat to format numeric values as US-style price strings.