### PR TITLE
ci: publish releases via GitHub Actions (OIDC trusted publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish
+
+on:
+    push:
+        tags: ['v[0-9]+.[0-9]+.[0-9]+']
+
+permissions:
+    contents: read
+    id-token: write
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v4
+            - name: Use Node.js 22.x
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22.x
+                  registry-url: 'https://registry.npmjs.org'
+                  cache: 'npm'
+            - name: Upgrade npm for trusted publishing (OIDC)
+              run: npm install -g npm@latest
+            - run: npm ci
+            - run: npm run lint
+            - run: npm run test
+            - run: npm run build
+            - name: Publish to npm (OIDC trusted publishing with provenance)
+              run: npm publish

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 **/out/**
 **/dist/**
+CHANGELOG.md
 

--- a/README.md
+++ b/README.md
@@ -320,6 +320,17 @@ const text = trimAndRemoveSpaces(' Hello World ');
 
 Contributions are welcome! If you'd like to report a bug, suggest a feature, or contribute to the codebase, feel free to open an issue or submit a pull request.
 
+## Releasing
+
+Releases are published to npm by CI, not from a developer machine.
+
+1. Branch, make your changes, then bump the version with `npm run release -- --release-as <patch|minor|major> --skip.tag`. This updates `package.json` and `CHANGELOG.md` and commits them.
+2. Open a pull request and merge it into `main` once CI is green.
+3. On `main`, create and push the matching tag: `git checkout main && git pull && git tag v<version> && git push origin v<version>`.
+4. Pushing a `v*` tag triggers the `Publish` workflow, which runs lint, tests, and build, then publishes to npm via trusted publishing (OIDC). No local `npm publish` and no npm token are needed.
+
+Trusted publishing must be configured once on npmjs.com: package settings -> Publishing access -> add a GitHub Actions trusted publisher for this repository with workflow `publish.yml`.
+
 ---
 
 ## **License**


### PR DESCRIPTION
## What

Moves releases off the developer machine and onto CI, so publishing no longer bypasses the `main` branch-protection rule.

- **`.github/workflows/publish.yml`** — new `Publish` workflow. Triggers on `v*.*.*` tag pushes, runs lint + tests + build, then `npm publish` using npm **trusted publishing (OIDC)**. No stored `NPM_TOKEN`, and provenance is attached automatically.
- **`.prettierignore`** — ignore the generated `CHANGELOG.md`. standard-version writes it in a shape Prettier rejects, which made the CI `format` step fail on every `chore(release)` commit (the 1.14.0 and 1.14.1 runs were both red).
- **`README.md`** — documents the new PR-based release flow.

## Why

Requested move to a PR-gated workflow. The direct push of the 1.14.1 release only succeeded because my account has bypass rights on `main`; this removes the need for that.

## New release flow

1. Branch, change, bump: `npm run release -- --release-as <patch|minor|major> --skip.tag`
2. PR -> merge to `main` (CI green)
3. On `main`: `git tag v<version> && git push origin v<version>`
4. Tag push triggers `Publish` -> npm

## One-time setup required (npmjs.com)

Trusted publishing must be enabled once on the package: **Settings -> Publishing access -> add a GitHub Actions trusted publisher** for `basal-john/essential-common-utils`, workflow `publish.yml`. Until that's configured, the workflow's `npm publish` will fail.

## Verification

- `npm run format` now exits 0 (was 1 on `CHANGELOG.md`)
- `npm run lint` clean
- 38/38 tests pass, build green

## Not covered

The publish workflow can't be exercised until the npm trusted publisher is configured and a tag is pushed; the tag trigger won't run on this PR.